### PR TITLE
Fix error with rectificationPeriod.endDate, caused by dates` different time zones

### DIFF
--- a/openprocurement/auctions/rubble/models.py
+++ b/openprocurement/auctions/rubble/models.py
@@ -244,7 +244,7 @@ class Auction(BaseAuction):
     def validate_rectificationPeriod(self, data, period):
         if not (period and period.startDate) or not period.endDate:
             return
-        if period.endDate > TZ.localize(calculate_business_date(data['tenderPeriod']['endDate'], -MINIMAL_PERIOD_FROM_RECTIFICATION_END, data).replace(tzinfo=None)):
+        if period.endDate > calculate_business_date(data['tenderPeriod']['endDate'], -MINIMAL_PERIOD_FROM_RECTIFICATION_END, data).astimezone(getattr(period.endDate, 'tzinfo', TZ)):
             raise ValidationError(u"rectificationPeriod.endDate should come at least 5 working days earlier than tenderPeriod.endDate")
 
     def validate_value(self, data, value):

--- a/openprocurement/auctions/rubble/tests/blanks/tender_blanks.py
+++ b/openprocurement/auctions/rubble/tests/blanks/tender_blanks.py
@@ -630,6 +630,29 @@ def create_auction_with_item_with_invalid_schema_properties(self):
     response = self.app.post_json(entrypoint, request_data, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
 
+def create_auction_and_go_active_tendering(self):
+    response = self.app.get('/auctions')
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(len(response.json['data']), 0)
+
+    data = deepcopy(self.initial_data)
+    data['status'] = 'draft'
+    data['auctionPeriod']['startDate'] = '2019-10-29T11:00:00.000000+03:00'
+
+    response = self.app.post_json('/auctions', {'data': data})
+    self.assertEqual(response.status, '201 Created')
+    auction = response.json['data']
+    owner_token = response.json['access']['token']
+
+    self.assertEqual(auction['status'], 'draft')
+
+    # patch auction status by auction owner
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(auction['id'], owner_token),
+                                   {"data": {"status": "active.tendering"}})
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    auction = response.json['data']
+    self.assertEqual(auction['status'], 'active.tendering')
 
 def additionalClassifications(self):
     auction_data = deepcopy(self.initial_data)

--- a/openprocurement/auctions/rubble/tests/tender.py
+++ b/openprocurement/auctions/rubble/tests/tender.py
@@ -69,6 +69,7 @@ from openprocurement.auctions.rubble.tests.blanks.tender_blanks import (
     patch_old_auction_rectificationPeriod_invalidationDate,
     delete_procurementMethodDetails,
     auction_Administrator_change,
+    create_auction_and_go_active_tendering,
     # AuctionFieldsEditingTest
     patch_auction_denied,
     patch_auction_during_rectification_period,
@@ -123,6 +124,7 @@ class AuctionResourceTest(BaseWebTest):
     test_guarantee = snitch(guarantee)
     test_auction_Administrator_change = snitch(auction_Administrator_change)
     test_delete_procurementMethodDetails = snitch(delete_procurementMethodDetails)
+    test_rectification_period_duration_when_change_status_to_active_tendering = snitch(create_auction_and_go_active_tendering)
 
 
 class AuctionFieldsEditingTest(BaseAuctionWebTest):


### PR DESCRIPTION
Якщо розглянути конкретний приклад:

**period.endDate** => 2019-10-23 21:00:00+03:00
**calculate_business_date(data['tenderPeriod']['endDate'], -MINIMAL_PERIOD_FROM_RECTIFICATION_END,data)** => 2019-10-23 20:00:00+02:00

Це один і той же час, але в різних часових поясах.

Потім в дати отриманої з calculate_business_date(...) (2019-10-23 20:00:00+02:00) тупо видаляється інфа про часову зону й прикріплюється статична часова зона, що вказана в конфігах без адаптації годин до відповідної часової зони.

Я змінив цю дію і переводжу дату отриману з calculate_business_date(...) в часовий пояс дати period.endDate, адаптуючи при цьому години до часового поясу.

Також був доданий юніт тест, що покриває дану ситуацію. Без даного фікса -- цей кейс кидав помилку 'rectificationPeriod.endDate should come at least 5 working days earlier than tenderPeriod.endDate'